### PR TITLE
Handle redirected/merged items properly

### DIFF
--- a/inc/core.php
+++ b/inc/core.php
@@ -389,6 +389,9 @@ $getPortalInfo = function() use ($api, $item_id, $lang_code, $sites, $site_order
 	$i18n = $GLOBALS['i18n'];
 	
 	$item_data  = $api->lookupItemData($item_id, $lang_code, $sites);
+	if ( isset($item_data["redirects"]) ) {
+		$item_id = $item_data["redirects"]["to"];
+	}
 	$item_label = getDeepData($item_data, ["labels", $lang_code, "value"], "({$item_id}: {$i18n['nolabel']})");
 	$item_desc  = getDeepData($item_data, ["descriptions", $lang_code, "value"]);
 	$sitelinks  = sortByKey(
@@ -406,6 +409,7 @@ $getPortalInfo = function() use ($api, $item_id, $lang_code, $sites, $site_order
 	$image_credits = getRelevantImageCredits($sites_linked);
 	
 	return [
+		"item_id" => $item_id,
 		"item_label" => $item_label,
 		"item_desc" => $item_desc,
 		"sitelinks" => $sitelinks,

--- a/web/portal.php
+++ b/web/portal.php
@@ -2,6 +2,10 @@
 
 $portal = $getPortalInfo();
 
+if ( $item_id !== $portal["item_id"] ) {
+	header("Location:{$self}/{$portal["item_id"]}/{$lang_code}");
+}
+
 $jquerySrc = ( htmlspecialchars($_SERVER['HTTP_HOST']) == 'localhost' ) ? "http://code.jquery.com/jquery-3.3.1.min.js" : "https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.3.1/jquery.min.js";
 $scripts = "<script type='text/javascript' src='{$jquerySrc}' defer></script>
 	<script type='text/javascript' src='{$self}/js/loadmore.js' defer></script>";


### PR DESCRIPTION
Return the item id that the lookup actually used,
and if different to the item id in the location
(i.e. the api followed a redirect), set a new
location with the redirection target's id.

Fixes #48 